### PR TITLE
Add OffsetFetch and OffsetCommit

### DIFF
--- a/kafka/offset_commit.go
+++ b/kafka/offset_commit.go
@@ -1,0 +1,110 @@
+package kafka
+
+type OffsetCommitRequest struct {
+	GroupId                   string
+	GenerationIdOrMemberEpoch int32
+	MemberId                  string
+	Topics                    []TopicOffsetCommit
+
+	Version int16
+}
+
+type TopicOffsetCommit struct {
+	Name             string
+	PartitionIndexes []TopicPartitionIndex
+}
+type TopicPartitionIndex struct {
+	PartitionIndex       int32
+	CommittedOffset      int64
+	CommittedLeaderEpoch int32
+	CommittedMetadata    *string
+}
+
+func (r *OffsetCommitRequest) Decode(pd PacketDecoder, version int16) error {
+	r.Version = version
+
+	if version <= 6 {
+		GroupId, err := pd.getString()
+		if err != nil {
+			return err
+		}
+		r.GroupId = GroupId
+
+		GenerationIdOrMemberEpoch, err := pd.getInt32()
+		if err != nil {
+			return err
+		}
+		r.GenerationIdOrMemberEpoch = GenerationIdOrMemberEpoch
+
+		MemberId, err := pd.getString()
+		if err != nil {
+			return err
+		}
+		r.MemberId = MemberId
+
+		topicLength, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		r.Topics = []TopicOffsetCommit{}
+		for i := 0; i < topicLength; i++ {
+			name, err := pd.getString()
+			if err != nil {
+				return err
+			}
+
+			partitionsLength, err := pd.getArrayLength()
+			if err != nil {
+				return err
+			}
+			partitions := []TopicPartitionIndex{}
+			for j := 0; j < partitionsLength; j++ {
+				partitionIndex, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				committedOffset, err := pd.getInt64()
+				if err != nil {
+					return err
+				}
+				committedLeaderEpoch, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				committedMetadata, err := pd.getNullableString()
+				if err != nil {
+					return err
+				}
+
+				partitions = append(partitions, TopicPartitionIndex{
+					PartitionIndex:       partitionIndex,
+					CommittedOffset:      committedOffset,
+					CommittedLeaderEpoch: committedLeaderEpoch,
+					CommittedMetadata:    committedMetadata,
+				})
+			}
+
+			r.Topics = append(r.Topics, TopicOffsetCommit{
+				Name:             name,
+				PartitionIndexes: partitions,
+			})
+		}
+	}
+
+	return nil
+}
+
+func (r *OffsetCommitRequest) key() int16 {
+	return 8
+}
+
+func (r *OffsetCommitRequest) version() int16 {
+	return r.Version
+}
+
+func (r *OffsetCommitRequest) requiredVersion() Version {
+	return MaxVersion
+}
+
+func (r *OffsetCommitRequest) CollectClientMetrics(srcHost string) {
+}

--- a/kafka/offset_fetch.go
+++ b/kafka/offset_fetch.go
@@ -26,7 +26,7 @@ func (r *OffsetFetchRequest) Decode(pd PacketDecoder, version int16) error {
 		if err != nil {
 			return err
 		}
-		r.Topics = make([]OffsetFetchRequestTopic, 0, topicLength)
+		r.Topics = []OffsetFetchRequestTopic{}
 		for i := 0; i < topicLength; i++ {
 			name, err := pd.getString()
 			if err != nil {
@@ -37,7 +37,7 @@ func (r *OffsetFetchRequest) Decode(pd PacketDecoder, version int16) error {
 			if err != nil {
 				return err
 			}
-			indexes := make([]int32, 0, indexesLength)
+			indexes := []int32{}
 			for j := 0; j < indexesLength; j++ {
 				index, err := pd.getInt32()
 				if err != nil {

--- a/kafka/offset_fetch.go
+++ b/kafka/offset_fetch.go
@@ -1,0 +1,73 @@
+package kafka
+
+type OffsetFetchRequest struct {
+	GroupId string
+	Topics  []OffsetFetchRequestTopic
+
+	Version int16
+}
+
+type OffsetFetchRequestTopic struct {
+	Name             string
+	PartitionIndexes []int32
+}
+
+func (r *OffsetFetchRequest) Decode(pd PacketDecoder, version int16) error {
+	r.Version = version
+
+	if version <= 5 {
+		GroupId, err := pd.getString()
+		if err != nil {
+			return err
+		}
+		r.GroupId = GroupId
+
+		topicLength, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		r.Topics = make([]OffsetFetchRequestTopic, 0, topicLength)
+		for i := 0; i < topicLength; i++ {
+			name, err := pd.getString()
+			if err != nil {
+				return err
+			}
+
+			indexesLength, err := pd.getArrayLength()
+			if err != nil {
+				return err
+			}
+			indexes := make([]int32, 0, indexesLength)
+			for j := 0; j < indexesLength; j++ {
+				index, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+
+				indexes = append(indexes, index)
+			}
+
+			r.Topics = append(r.Topics, OffsetFetchRequestTopic{
+				Name:             name,
+				PartitionIndexes: indexes,
+			})
+		}
+	}
+
+	return nil
+}
+
+func (r *OffsetFetchRequest) key() int16 {
+	return 9
+}
+
+func (r *OffsetFetchRequest) version() int16 {
+	return r.Version
+}
+
+func (r *OffsetFetchRequest) requiredVersion() Version {
+	return MaxVersion
+}
+
+func (r *OffsetFetchRequest) CollectClientMetrics(srcHost string) {
+}

--- a/kafka/request.go
+++ b/kafka/request.go
@@ -161,6 +161,8 @@ func allocateBody(key, version int16) ProtocolBody {
 		return &ProduceRequest{}
 	case 1:
 		return &FetchRequest{Version: version}
+	case 9:
+		return &OffsetFetchRequest{}
 	}
 	return nil
 }

--- a/kafka/request.go
+++ b/kafka/request.go
@@ -161,6 +161,8 @@ func allocateBody(key, version int16) ProtocolBody {
 		return &ProduceRequest{}
 	case 1:
 		return &FetchRequest{Version: version}
+	case 8:
+		return &OffsetCommitRequest{}
 	case 9:
 		return &OffsetFetchRequest{}
 	}

--- a/stream/kafka.go
+++ b/stream/kafka.go
@@ -106,6 +106,12 @@ func (h *KafkaStream) run() {
 				// add consumer and topic relation info into metric
 				h.metricsStorage.AddConsumerTopicRelationInfo(h.net.Src().String(), topic)
 			}
+		case *kafka.OffsetFetchRequest:
+			if h.verbose {
+				for _, topic := range body.Topics {
+					log.Printf("client %s:%s joined group %s to read topic %s", h.net.Src(), h.transport.Src(), body.GroupId, topic.Name)
+				}
+			}
 		}
 	}
 }

--- a/stream/kafka.go
+++ b/stream/kafka.go
@@ -112,6 +112,12 @@ func (h *KafkaStream) run() {
 					log.Printf("client %s:%s joined group %s to read topic %s", h.net.Src(), h.transport.Src(), body.GroupId, topic.Name)
 				}
 			}
+		case *kafka.OffsetCommitRequest:
+			if h.verbose {
+				for _, topic := range body.Topics {
+					log.Printf("client %s:%s committed offset to group %s of topic %s", h.net.Src(), h.transport.Src(), body.GroupId, topic.Name)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
First of all **thank you** for this package and the work you've put into it.

I have implemented OffsetCommit Request (Version 5) and OffsetFetch Request (Version 6). This is tested against Kafka 2.2.2.

This enables the tracking of:

- consumer groups  
- when a new consumer first joins or a rebalance occurs.

I did not implement `CollectClientMetrics` for these requests since we're not using metrics at the moment. 

Hope this is useful!

PS: Happy to modify this further if you think it's necessary 👍 